### PR TITLE
Fix migration link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can find the _BlinkID_ SDK **KDoc** documentation [here](https://microblink.
 
 Detailed documentation can be found on our [documentation page](https://docs.microblink.com/blinkid/next).
 
-Transition guide from v7 to v8000 can be found on our [migration page](https://docs.microblink.com/blinkid/next/migration-v8000?platform=android).
+Transition guide from v7 to v8000 can be found on our [migration page](https://docs.microblink.com/blinkid/migration-v8000?platform=android).
 
 # <a name="quick-start"></a> Quick Start
 

--- a/Release notes.md
+++ b/Release notes.md
@@ -49,7 +49,7 @@
 - Date Conversion Accuracy: Resolved an issue where Islamic-to-Gregorian date conversions could occasionally differ by +/- 1 day. These conversions are now precise and consistent.
 
 ### API changes
-- For detailed API changes and migration guide, visit our [documentation page](https://docs.microblink.com/blinkid/next/migration-v8000?platform=android).
+- For detailed API changes and migration guide, visit our [documentation page](https://docs.microblink.com/blinkid/migration-v8000?platform=android).
 
 
 ## v7.8.1

--- a/Transition guide.md
+++ b/Transition guide.md
@@ -2,7 +2,7 @@
 
 ## BlinkID SDK v7 to BlinkID SDK v8000
  
- Detailed transition guide can be found on our [documentation page](https://docs.microblink.com/blinkid/next/migration-v8000?platform=android).
+ Detailed transition guide can be found on our [documentation page](https://docs.microblink.com/blinkid/migration-v8000?platform=android).
 
 
 ## BlinkID SDK v6 to BlinkID SDK v7


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration and release notes links to point to the current BlinkID v8000 guide location.
  * Fixed the transition guide link so it opens the correct Android migration page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->